### PR TITLE
Include project workspace and ignore xcuserdata.

### DIFF
--- a/openspringboard/openspringboard.xcodeproj/.gitignore
+++ b/openspringboard/openspringboard.xcodeproj/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/openspringboard/openspringboard.xcodeproj/project.xcworkspace/.gitignore
+++ b/openspringboard/openspringboard.xcodeproj/project.xcworkspace/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/openspringboard/openspringboard.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/openspringboard/openspringboard.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:openspringboard.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
The project workspace contains common schemes that should be included with the project.
xcuserdata contains only user-specific settings and should not be included with the project.
